### PR TITLE
CI: Run Tests workflow with mode picker (regression / suite / filter)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,115 @@
+name: Run Tests
+
+# Manual-trigger only. Visible as the "Run Tests" workflow in the
+# Actions tab — click "Run workflow" to get a form with the inputs
+# below. Result renders on the run page using the same green/red
+# summary as the auto CI workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'What to run'
+        type: choice
+        required: true
+        default: 'all'
+        options:
+          - 'all'
+          - 'regression-only'
+          - 'specific-suite'
+          - 'custom-filter'
+      suite:
+        description: 'Suite name (used when mode = specific-suite). Examples: CombineEngineTests, VideoScanTests/DuplicateDetectorTests'
+        type: string
+        required: false
+        default: ''
+      filter:
+        description: 'Raw xcodebuild flags (used when mode = custom-filter). Example: -only-testing:VideoScanTests/Foo -skip-testing:VideoScanTests/Bar'
+        type: string
+        required: false
+        default: ''
+      include_ui_tests:
+        description: 'Include VideoScanUITests target (slower, sometimes flaky)'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  run-tests:
+    name: ${{ inputs.mode }} ${{ inputs.suite }}
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: Show inputs
+        run: |
+          echo "## Run Tests — inputs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Mode | \`${{ inputs.mode }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Suite | \`${{ inputs.suite }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Filter | \`${{ inputs.filter }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Include UI tests | \`${{ inputs.include_ui_tests }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Build test filter args
+        id: filter
+        env:
+          MODE: ${{ inputs.mode }}
+          SUITE: ${{ inputs.suite }}
+          FILTER: ${{ inputs.filter }}
+          INCLUDE_UI: ${{ inputs.include_ui_tests }}
+        run: |
+          chmod +x scripts/build_test_filter.sh
+          echo "Resolved xcodebuild filter args:"
+          scripts/build_test_filter.sh | tee filter-args.txt
+          # Make filter-args.txt available to subsequent steps as a
+          # newline-separated file (xcodebuild gets each arg via xargs).
+
+      - name: Run tests
+        run: |
+          # Read filter args into a bash array
+          filter_args=()
+          while IFS= read -r line; do
+            [ -n "$line" ] && filter_args+=("$line")
+          done < filter-args.txt
+
+          echo "xcodebuild filter args: ${filter_args[@]}"
+
+          xcodebuild test \
+            -project VideoScan/VideoScan.xcodeproj \
+            -scheme VideoScan \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            MACOSX_DEPLOYMENT_TARGET=15.0 \
+            "${filter_args[@]}" \
+            2>&1 | tee xcodebuild-test.log
+
+          # Fail the job if any test failed (but still let summary step run).
+          if grep -q "Testing failed" xcodebuild-test.log; then
+            echo "::error::Tests failed — see Summary panel for details"
+            exit 1
+          fi
+
+      - name: Test Summary (pass/fail with details)
+        if: always()
+        run: |
+          chmod +x scripts/ci_test_summary.sh
+          scripts/ci_test_summary.sh TestResults.xcresult
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.mode }}
+          path: TestResults.xcresult
+          retention-days: 14

--- a/scripts/build_test_filter.sh
+++ b/scripts/build_test_filter.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# build_test_filter.sh — emit xcodebuild -only-testing flags from
+# workflow_dispatch inputs. Reads env vars set by the GH workflow:
+#
+#   MODE        : all | regression-only | specific-suite | custom-filter
+#   SUITE       : suite name (with or without "VideoScanTests/" prefix)
+#   FILTER      : free-form xcodebuild test arg, used verbatim
+#   INCLUDE_UI  : 'true' to include VideoScanUITests target
+#
+# Each output line is one xcodebuild argument. Caller does:
+#
+#   args=()
+#   while IFS= read -r a; do args+=("$a"); done < <(scripts/build_test_filter.sh)
+#   xcodebuild test "${args[@]}" ...
+#
+# Locally testable:
+#   MODE=regression-only ./scripts/build_test_filter.sh
+
+set -euo pipefail
+
+MODE="${MODE:-all}"
+SUITE="${SUITE:-}"
+FILTER="${FILTER:-}"
+INCLUDE_UI="${INCLUDE_UI:-false}"
+
+emit_suite() {
+    local s="$1"
+    if [[ "$s" == */* ]]; then
+        echo "-only-testing:$s"
+    else
+        echo "-only-testing:VideoScanTests/$s"
+    fi
+}
+
+case "$MODE" in
+    all)
+        # Restrict to the unit-test target unless UI tests requested.
+        if [ "$INCLUDE_UI" != "true" ]; then
+            echo "-only-testing:VideoScanTests"
+        fi
+        # No filter args = run everything in the scheme.
+        ;;
+
+    regression-only)
+        # Walk every test file, track the enclosing struct, and emit
+        # `-only-testing:VideoScanTests/<Suite>` for each suite that
+        # contains a `// regression:` marker. Suites are deduped.
+        # Matches all decoration patterns (`@Suite(...) struct X`,
+        # `@MainActor` on prior line, `@Suite @MainActor struct X`,
+        # plain `struct X`, etc.) by looking for "struct " on any
+        # non-comment line and capturing the next identifier.
+        for f in VideoScan/VideoScanTests/*.swift; do
+            [ -f "$f" ] || continue
+            awk '
+                /struct[[:space:]]+[A-Za-z_]/ && $0 !~ /^[[:space:]]*\/\// {
+                    s = $0
+                    sub(/^.*struct[[:space:]]+/, "", s)
+                    sub(/[^A-Za-z0-9_].*/, "", s)
+                    if (s != "") current = s
+                }
+                /\/\/ regression:/ {
+                    if (current != "") print current
+                }
+            ' "$f"
+        done | sort -u | while IFS= read -r suite; do
+            [ -n "$suite" ] && emit_suite "$suite"
+        done
+        ;;
+
+    specific-suite)
+        if [ -z "$SUITE" ]; then
+            echo "ERROR: specific-suite mode needs SUITE input" >&2
+            exit 2
+        fi
+        emit_suite "$SUITE"
+        ;;
+
+    custom-filter)
+        if [ -z "$FILTER" ]; then
+            echo "ERROR: custom-filter mode needs FILTER input" >&2
+            exit 2
+        fi
+        # Pass through verbatim. Caller may have supplied multiple
+        # space-separated flags; split on whitespace.
+        printf '%s\n' $FILTER
+        ;;
+
+    *)
+        echo "ERROR: unknown mode '$MODE'" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Adds a manual-trigger workflow that puts a form on the Actions tab letting you pick what to run.
- Modes: \`all\` / \`regression-only\` / \`specific-suite\` / \`custom-filter\`. Plus an \"include UI tests\" toggle.
- \`regression-only\` walks the test files for \`// regression:\` markers and builds the suite list dynamically — auto-extends as we add markers.
- Reuses the green/red summary panel from #48.

**Stacks on top of #48.** The PR base is \`feature/ci-test-summary\`; once that merges to main, this one rebases automatically.

## Test plan
- [x] Locally exercised \`scripts/build_test_filter.sh\` with all 4 modes, output looks right.
- [ ] Trigger via Actions → Run Tests → pick \`regression-only\` → confirm CI runs only the regression-tagged suites and the summary panel shows the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)