### PR TITLE
Fix 16 concurrency warnings: realtime window observers + VolumeCompare hot loop

### DIFF
--- a/VideoScan/VideoScan/RealtimeCatalogScanWindow.swift
+++ b/VideoScan/VideoScan/RealtimeCatalogScanWindow.swift
@@ -459,16 +459,20 @@ class CatalogScanWindowController {
         w.center()
         w.makeKeyAndOrderFront(nil)
         window = w
+        // Notification block runs on .main queue but Swift treats it as
+        // Sendable; explicit @MainActor hop satisfies strict concurrency.
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: w,
             queue: .main
         ) { [weak self] _ in
-            guard let self else { return }
-            self.window = nil
-            if let obs = self.closeObserver {
-                NotificationCenter.default.removeObserver(obs)
-                self.closeObserver = nil
+            Task { @MainActor in
+                guard let self else { return }
+                self.window = nil
+                if let obs = self.closeObserver {
+                    NotificationCenter.default.removeObserver(obs)
+                    self.closeObserver = nil
+                }
             }
         }
     }

--- a/VideoScan/VideoScan/RealtimeFaceDetectionWindow.swift
+++ b/VideoScan/VideoScan/RealtimeFaceDetectionWindow.swift
@@ -467,16 +467,20 @@ class PreviewWindowController {
         window = w
         // When the user closes via the red button, drop our reference so the
         // next show() builds a fresh window instead of trying to reopen one.
+        // Notification block runs on the main queue, but Swift's strict
+        // concurrency treats it as Sendable — explicit @MainActor hop.
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: w,
             queue: .main
         ) { [weak self] _ in
-            guard let self else { return }
-            self.window = nil
-            if let obs = self.closeObserver {
-                NotificationCenter.default.removeObserver(obs)
-                self.closeObserver = nil
+            Task { @MainActor in
+                guard let self else { return }
+                self.window = nil
+                if let obs = self.closeObserver {
+                    NotificationCenter.default.removeObserver(obs)
+                    self.closeObserver = nil
+                }
             }
         }
     }
@@ -624,16 +628,20 @@ class JobConsoleWindowController {
         w.center()
         w.makeKeyAndOrderFront(nil)
         window = w
+        // Notification block runs on .main queue but Swift treats it as
+        // Sendable; explicit @MainActor hop satisfies strict concurrency.
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: w,
             queue: .main
         ) { [weak self] _ in
-            guard let self else { return }
-            self.window = nil
-            if let obs = self.closeObserver {
-                NotificationCenter.default.removeObserver(obs)
-                self.closeObserver = nil
+            Task { @MainActor in
+                guard let self else { return }
+                self.window = nil
+                if let obs = self.closeObserver {
+                    NotificationCenter.default.removeObserver(obs)
+                    self.closeObserver = nil
+                }
             }
         }
     }

--- a/VideoScan/VideoScan/VolumeCompare.swift
+++ b/VideoScan/VideoScan/VolumeCompare.swift
@@ -178,14 +178,21 @@ final class VolumeRescueOperation: ObservableObject {
         for (idx, rec) in files.enumerated() {
             if Task.isCancelled { break }
 
+            // Pull Sendable fields off the VideoRecord up front. VideoRecord
+            // is a class with mutable state so closures can't capture it
+            // across the MainActor boundary; capturing the String/Int64
+            // values is safe and keeps the type checker happy.
             let srcFile = rec.fullPath
-            let relative = Self.relativePath(srcFile, under: sourcePath, fallback: rec.filename)
+            let filename = rec.filename
+            let sizeBytes = rec.sizeBytes
+            let relative = Self.relativePath(srcFile, under: sourcePath, fallback: filename)
             let destFile = (rescueDir as NSString).appendingPathComponent(relative)
             let destDir = (destFile as NSString).deletingLastPathComponent
+            let progressFraction = Double(idx) / Double(total)
 
             await MainActor.run { [weak self] in
-                self?.currentFile = rec.filename
-                self?.progress = Double(idx) / Double(total)
+                self?.currentFile = filename
+                self?.progress = progressFraction
             }
 
             do {
@@ -201,7 +208,7 @@ final class VolumeRescueOperation: ObservableObject {
             if fm.fileExists(atPath: destFile) {
                 await MainActor.run { [weak self] in
                     self?.filesCopied += 1
-                    self?.bytesWritten += rec.sizeBytes
+                    self?.bytesWritten += sizeBytes
                 }
                 continue
             }
@@ -210,7 +217,7 @@ final class VolumeRescueOperation: ObservableObject {
                 try fm.copyItem(atPath: srcFile, toPath: destFile)
                 await MainActor.run { [weak self] in
                     self?.filesCopied += 1
-                    self?.bytesWritten += rec.sizeBytes
+                    self?.bytesWritten += sizeBytes
                 }
             } catch {
                 await MainActor.run { [weak self] in
@@ -229,14 +236,18 @@ final class VolumeRescueOperation: ObservableObject {
         for (idx, rec) in files.enumerated() {
             if Task.isCancelled { break }
 
+            // See fastCopy: capture Sendable fields, not the VideoRecord ref.
             let srcFile = rec.fullPath
-            let relative = Self.relativePath(srcFile, under: sourcePath, fallback: rec.filename)
+            let filename = rec.filename
+            let sizeBytes = rec.sizeBytes
+            let relative = Self.relativePath(srcFile, under: sourcePath, fallback: filename)
             let destFile = (rescueDir as NSString).appendingPathComponent(relative)
             let destDir = (destFile as NSString).deletingLastPathComponent
+            let progressFraction = Double(idx) / Double(total)
 
             await MainActor.run { [weak self] in
-                self?.currentFile = rec.filename
-                self?.progress = Double(idx) / Double(total)
+                self?.currentFile = filename
+                self?.progress = progressFraction
             }
 
             // Create destination directory
@@ -275,7 +286,7 @@ final class VolumeRescueOperation: ObservableObject {
                 if proc.terminationStatus == 0 {
                     await MainActor.run { [weak self] in
                         self?.filesCopied += 1
-                        self?.bytesWritten += rec.sizeBytes
+                        self?.bytesWritten += sizeBytes
                     }
                 } else {
                     let errData = errPipe.fileHandleForReading.readDataToEndOfFile()


### PR DESCRIPTION
## Summary
Real-bug-risk fixes flagged by last night's strict-concurrency analysis. Both would be hard errors in Swift 6 mode.

**Realtime windows (6 warnings)** — \`closeObserver\` mutated from a Sendable notification block. Wrapped block bodies in \`Task { @MainActor in ... }\`.

**VolumeCompare fastCopy + rsyncCopy (10 warnings)** — captured a \`VideoRecord\` (mutable class, not Sendable) into \`MainActor.run\` closures. Real race risk: if record fields mutate concurrently, the UI observes mid-mutation. Fixed by extracting the Sendable value-type fields (\`filename\`, \`sizeBytes\`, \`fullPath\`) before the closure.

## Test plan
- [x] Local Debug build with \`SWIFT_STRICT_CONCURRENCY=complete -warn-concurrency\`: confirmed 16 targeted warnings → 0.
- [x] Plain Debug build: \`** BUILD SUCCEEDED **\`.
- [ ] Trigger nightly workflow_dispatch on this branch — confirm \`concurrency_warnings\` count drops by ~16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)