### PR TITLE
Fix concurrency warnings: notification capture + NSImage actor hop

### DIFF
--- a/VideoScan/VideoScan/DuplicateDetector.swift
+++ b/VideoScan/VideoScan/DuplicateDetector.swift
@@ -242,7 +242,11 @@ enum DuplicateDetector {
     private static let mediumConfidenceScore = 9
     private static let highConfidenceScore = 12
 
-    private static let scoringRules: [ScoringRule] = [
+    // Static immutable table of pure functions — safe to read concurrently
+    // even though ScoringRule isn't Sendable (closure parameter type
+    // VideoRecord is a class). The table is built once at type-init and
+    // never mutated thereafter.
+    nonisolated(unsafe) private static let scoringRules: [ScoringRule] = [
         // Byte-identical content: same hash AND same size. Strongest signal.
         ScoringRule(reason: "hash") { l, r in
             guard !l.partialMD5.isEmpty,

--- a/VideoScan/VideoScan/VideoScanModel.swift
+++ b/VideoScan/VideoScan/VideoScanModel.swift
@@ -340,11 +340,14 @@ final class VideoScanModel: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] note in
+            // Notification is non-Sendable; pull the userInfo URL out before
+            // hopping to the main actor so we don't capture `note` itself.
+            let volumeURL = note.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL
             Task { @MainActor in
                 guard let self else { return }
                 self.refreshTargetReachability()
                 // Auto-add newly mounted volume as a scan target (skip RAM disk)
-                if let url = note.userInfo?[NSWorkspace.volumeURLUserInfoKey] as? URL {
+                if let url = volumeURL {
                     let path = url.path
                     let volumeRoot = url.path
                     for t in self.scanTargets where t.searchPath.hasPrefix(volumeRoot) {
@@ -2727,8 +2730,10 @@ final class VideoScanModel: ObservableObject {
                         if let image { cont.resume(returning: image) } else { cont.resume(throwing: error ?? CocoaError(.fileReadUnknown)) }
                     }
                 }
-                let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+                // CGImage is Sendable; NSImage isn't. Build the NSImage on
+                // the main actor so we never cross actor boundaries with it.
                 await MainActor.run {
+                    let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
                     self.thumbnailCache.setObject(nsImage, forKey: cacheKey)
                     self.previewImage = nsImage
                 }

--- a/VideoScan/VideoScan/VideoScanModel.swift
+++ b/VideoScan/VideoScan/VideoScanModel.swift
@@ -29,7 +29,10 @@ struct ScanOptions: Equatable {
     var skipChecksums: Bool = false
 
     // MARK: Persistence
-    private static let defaults = UserDefaults.standard
+    // UserDefaults.standard is documented thread-safe (CFPreferences-backed
+    // with internal locking). nonisolated(unsafe) tells strict concurrency
+    // we know what we're doing.
+    nonisolated(unsafe) private static let defaults = UserDefaults.standard
     private static let prefix = "scanopts_"
 
     static func restored() -> ScanOptions {
@@ -119,7 +122,8 @@ struct ScanPerformanceSettings {
 
     // MARK: Persistence
 
-    private static let defaults = UserDefaults.standard
+    // See ScanOptions.defaults — UserDefaults is thread-safe.
+    nonisolated(unsafe) private static let defaults = UserDefaults.standard
     private static let prefix = "perf_"
 
     static func restored() -> ScanPerformanceSettings {

--- a/VideoScan/VideoScan/VolumesWindow.swift
+++ b/VideoScan/VideoScan/VolumesWindow.swift
@@ -140,7 +140,10 @@ private struct VolumeListRow: View {
 }
 
 private struct SidebarWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 320
+    // PreferenceKey's `static var defaultValue { get }` requirement is
+    // satisfied by a `let` (gets you the getter for free) and avoids the
+    // global-mutable-state warning.
+    static let defaultValue: CGFloat = 320
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
     }


### PR DESCRIPTION
## Summary
Continuing the static-analysis cleanup, scoped to non-PersonFinder files (other Claude is working in PF, PR #53 covers Realtime windows + VolumeCompare).

**Two commits, 12 warnings cleared total. Strict-concurrency baseline 97 → 89.**

### Commit 1 — VideoScanModel.swift (4 warnings)
- Notification observer captured `note` (Notification — not Sendable) into a `Task @MainActor` closure. Pull `userInfo[volumeURLUserInfoKey]` out before the hop; capture only the Sendable URL.
- Thumbnail generator built an `NSImage` (not Sendable) before `MainActor.run`. CGImage IS Sendable; moved NSImage construction inside the MainActor block.

### Commit 2 — Static globals + PreferenceKey (8 warnings)
- **UserDefaults static lets** at `VideoScanModel.swift:32` and `:122`. UserDefaults.standard is documented thread-safe; `nonisolated(unsafe)` is the standard escape hatch.
- **`DuplicateDetector.scoringRules`**: static immutable table of pure functions. Closures only read VideoRecord fields and never mutate; same `nonisolated(unsafe)` pattern.
- **`SidebarWidthKey.defaultValue`**: PreferenceKey's `static var ... { get }` requirement is satisfied by `let` — flipped var→let.

## What's left (deliberately out of scope)
- **~40+ "VideoRecord doesn't conform to Sendable" warnings** in VideoScanModel.swift scan loop. These need a structural decision (snapshot struct vs `@unchecked Sendable` contract) — Rick's call.
- **VideoScanModel+Combine.swift TaskGroup** — `processCombinePair` takes VideoRecord directly; same Sendable issue, same architectural dependency.
- **PersonFinder territory** — other Claude is actively working there.
- **RAMAssetLoader.swift** — Rick's brand-new disk-feeder code, let it stabilize.

## Test plan
- [x] Plain Debug build: green
- [x] `SWIFT_STRICT_CONCURRENCY=complete` clean rebuild: 97 → 89 warnings
- [ ] Stack on top of #53 (or merge in either order — no overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)