### PR TITLE
Static analysis: real Periphery 3.x + CodeQL manual build mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,13 @@ jobs:
 
       - name: Install SwiftLint & Periphery
         run: |
-          brew install swiftlint periphery
+          # Force latest Periphery — runner image caches an older version
+          # (was 2.21.2; tap installs are 3.x+). 3.x has new findings
+          # categories that 2.x silently misses.
+          brew install swiftlint || true
+          brew install peripheryapp/periphery/periphery 2>/dev/null \
+            || brew upgrade peripheryapp/periphery/periphery
+          echo "Periphery: $(periphery version)"
 
       - name: SwiftLint (warn-only for now)
         # Non-blocking so we can ratchet down violations gradually.
@@ -77,7 +83,9 @@ jobs:
         run: |
           echo "## Periphery — unused code" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          periphery scan 2>&1 | tee periphery-raw.txt | tee -a $GITHUB_STEP_SUMMARY || true
+          # --exclude-tests: test helpers are allowed to look "unused";
+          # the nightly job runs without this flag for the aggressive view.
+          periphery scan --exclude-tests 2>&1 | tee periphery-raw.txt | tee -a $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "PERIPHERY_OUTPUT=$(pwd)/periphery-raw.txt" >> $GITHUB_ENV
 

--- a/.github/workflows/nightly-analysis.yml
+++ b/.github/workflows/nightly-analysis.yml
@@ -164,6 +164,12 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: swift
+          # `manual` mode tells CodeQL to extract from our explicit build
+          # below rather than racing its own autobuild. Previously the
+          # SARIF showed 177 "cannot find type 'PhotosPickerItem' in scope"
+          # indexer errors and 0 results — autobuild was producing a
+          # partial AST that the analyse step then queried.
+          build-mode: manual
           queries: security-and-quality
 
       - name: Build for CodeQL
@@ -326,8 +332,14 @@ jobs:
 
       - name: Install tools
         run: |
-          brew list swiftlint >/dev/null 2>&1 || brew install swiftlint
-          brew list periphery >/dev/null 2>&1 || brew install peripheryapp/periphery/periphery
+          # Force latest Periphery — the runner image caches 2.21.2;
+          # 3.x finds findings the older version misses (the previous
+          # nightly reported "No unused code detected" because of this).
+          brew install swiftlint || true
+          brew install peripheryapp/periphery/periphery 2>/dev/null \
+            || brew upgrade peripheryapp/periphery/periphery
+          echo "Periphery: $(periphery version)"
+          echo "SwiftLint: $(swiftlint version)"
 
       - name: SwiftLint --strict
         run: |

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -11,8 +11,11 @@ project: VideoScan/VideoScan.xcodeproj
 schemes:
   - VideoScan
 
-# Skip test targets from analysis — they're allowed to have unused helpers.
-exclude_tests: true
+# NOTE: --exclude-tests moved to CLI flag in Periphery 3.x (the old
+# `exclude_tests:` YAML key is rejected as invalid). Each workflow now
+# passes the flag explicitly:
+#   ci.yml          → --exclude-tests (test helpers can be unused)
+#   nightly         → no flag        (aggressive — find unused test helpers too)
 
 # Don't complain about symbols that SwiftUI and Codable need:
 # - SwiftUI `body` property and related implicit conformances


### PR DESCRIPTION
## Why
Investigated why three nightly metrics were 0 (Periphery aggressive, CodeQL findings, TSan races).

| Tool | Diagnosis |
|---|---|
| Periphery | Cached 2.21.2 in runner image; 3.x finds things 2.21.2 misses. \`exclude_tests\` YAML key was invalid in 3.x. |
| CodeQL | autobuild produced a partial AST (177 \"cannot find type 'PhotosPickerItem'\" indexer errors). |
| TSan | Genuinely zero — no actual races detected, tests just don't exercise much concurrency. Left as-is. |

## What changed
1. \`.periphery.yml\` — removed deprecated \`exclude_tests:\` key
2. \`ci.yml\` — force Periphery upgrade, pass \`--exclude-tests\` on CLI (regular CI = test helpers can be unused)
3. \`nightly-analysis.yml\` — force Periphery upgrade (aggressive scan with no \`--exclude-tests\`), add \`build-mode: manual\` to CodeQL

## Test plan
- [x] Both workflow files YAML-parse clean
- [x] Periphery 3.7.4 confirmed produces findings on this codebase locally
- [ ] Trigger nightly workflow_dispatch on this branch — confirm Periphery returns non-zero count and CodeQL no longer shows 177 indexer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)