### PR TITLE
Universal search + triage disposition (issue #66, patterns 2 & 3)

### DIFF
--- a/VideoScan/VideoScan/CatalogQueries.swift
+++ b/VideoScan/VideoScan/CatalogQueries.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+// MARK: - Universal search (issue #66, pattern 2)
+//
+// Multi-token AND search across every catalog field a user might think
+// of: filename, path, year, detectedPeople, avidClipName, codec,
+// lifecycleStage. Pure functions so the same logic can drive a search
+// bar in any tab plus power scripted queries.
+
+/// A single search token. Most are plain substrings, but year ranges
+/// like "1990s" / "199x" are first-class so the user can type them
+/// naturally.
+enum SearchToken: Equatable {
+    case substring(String)              // case-insensitive contains
+    case yearRange(ClosedRange<Int>)    // e.g. 1990...1999 for "1990s"
+}
+
+/// Split a search query into tokens. Whitespace separates tokens; each
+/// token is recognised as a year shorthand if it matches `YYYYs` or
+/// `YYYx`, otherwise treated as a substring.
+///
+///     "donna 1990s holiday"
+///       → [.substring("donna"), .yearRange(1990...1999), .substring("holiday")]
+nonisolated func pfTokenizeSearchQuery(_ query: String) -> [SearchToken] {
+    let parts = query.split(whereSeparator: \.isWhitespace).map(String.init)
+    return parts.compactMap { part in
+        let trimmed = part.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { return nil }
+        // Year decade shorthand: "1990s", "1990S"
+        if trimmed.count == 5,
+           let prefix = Int(trimmed.dropLast()),
+           trimmed.last?.lowercased() == "s",
+           prefix >= 1900, prefix <= 2099,
+           prefix % 10 == 0 {
+            return .yearRange(prefix...(prefix + 9))
+        }
+        // Year wildcard: "199x", "200x"
+        if trimmed.count == 4,
+           trimmed.last?.lowercased() == "x",
+           let prefix = Int(trimmed.dropLast()),
+           prefix >= 190, prefix <= 209 {
+            let base = prefix * 10
+            return .yearRange(base...(base + 9))
+        }
+        return .substring(trimmed)
+    }
+}
+
+/// Extract any 4-digit years (1900–2099) found in a catalog record's
+/// path or filename. Used by universal search for year-token matching.
+nonisolated func pfYearsFromRecord(_ rec: VideoRecord) -> Set<Int> {
+    var years = Set<Int>()
+    let haystack = rec.fullPath + " " + rec.directory + " " + rec.filename
+    var index = haystack.startIndex
+    while index < haystack.endIndex {
+        // Find a run of 4 digits.
+        if haystack[index].isNumber,
+           let end = haystack.index(index, offsetBy: 4, limitedBy: haystack.endIndex) {
+            let chunk = haystack[index..<end]
+            if chunk.allSatisfy(\.isNumber), let y = Int(chunk),
+               y >= 1900, y <= 2099 {
+                // Reject if it's part of a longer digit run (e.g. "19999").
+                let nextIsDigit = end < haystack.endIndex && haystack[end].isNumber
+                let prevIdx = index > haystack.startIndex
+                    ? haystack.index(before: index) : haystack.startIndex
+                let prevIsDigit = index > haystack.startIndex && haystack[prevIdx].isNumber
+                if !nextIsDigit && !prevIsDigit {
+                    years.insert(y)
+                }
+            }
+        }
+        index = haystack.index(after: index)
+    }
+    // Also use dateModifiedRaw / dateCreatedRaw years if available.
+    let cal = Calendar(identifier: .gregorian)
+    if let d = rec.dateModifiedRaw {
+        years.insert(cal.component(.year, from: d))
+    }
+    if let d = rec.dateCreatedRaw {
+        years.insert(cal.component(.year, from: d))
+    }
+    return years
+}
+
+/// Return true if `token` matches any field on `record`.
+nonisolated func pfTokenMatches(_ token: SearchToken, _ rec: VideoRecord) -> Bool {
+    switch token {
+    case .substring(let needle):
+        let n = needle.lowercased()
+        if rec.filename.lowercased().contains(n) { return true }
+        if rec.fullPath.lowercased().contains(n) { return true }
+        if rec.directory.lowercased().contains(n) { return true }
+        if rec.detectedPeople.contains(where: { $0.lowercased().contains(n) }) { return true }
+        if rec.avidClipName.lowercased().contains(n) { return true }
+        if rec.videoCodec.lowercased().contains(n) { return true }
+        if rec.audioCodec.lowercased().contains(n) { return true }
+        if rec.lifecycleStage.rawValue.lowercased().contains(n) { return true }
+        if rec.archiveStage.rawValue.lowercased().contains(n) { return true }
+        if rec.notes.lowercased().contains(n) { return true }
+        return false
+    case .yearRange(let range):
+        return pfYearsFromRecord(rec).contains(where: { range.contains($0) })
+    }
+}
+
+/// Universal-search entry point. All tokens must match (AND semantics);
+/// empty query → matches everything.
+nonisolated func pfRecordMatchesQuery(_ rec: VideoRecord, query: String) -> Bool {
+    let tokens = pfTokenizeSearchQuery(query)
+    if tokens.isEmpty { return true }
+    return tokens.allSatisfy { pfTokenMatches($0, rec) }
+}
+
+/// Convenience: filter a record list against a query string.
+nonisolated func pfRecordsMatchingQuery(_ records: [VideoRecord], query: String) -> [VideoRecord] {
+    let tokens = pfTokenizeSearchQuery(query)
+    if tokens.isEmpty { return records }
+    return records.filter { rec in tokens.allSatisfy { pfTokenMatches($0, rec) } }
+}
+
+// MARK: - Triage disposition (issue #66, pattern 3)
+//
+// junkScore today is just a column. Promote it to a triage assist:
+// records below `autoJunkBelow` are auto-junkable IFF a verified backup
+// exists; records above `autoKeepAbove` are auto-keep; the band in
+// between is what the human actually has to triage. Trims the queue
+// to the records where the human call matters.
+
+enum TriageDisposition: String, Equatable {
+    /// junkScore high enough to keep automatically.
+    case autoKeep
+    /// In the borderline band — human review required.
+    case queue
+    /// Score low enough to auto-junk, AND backup safety gate satisfied.
+    case autoJunk
+    /// Score low enough to auto-junk but backup gate NOT satisfied —
+    /// queue it for the human (don't risk catastrophic loss).
+    case junkButNotBackedUp
+}
+
+/// "Backup-verified" means: at least two distinct backup destinations,
+/// OR archiveStage marked as healthy / backed-up. Conservative on
+/// purpose — auto-delete should only fire when we're CONFIDENT.
+nonisolated func pfRecordHasVerifiedBackup(_ rec: VideoRecord) -> Bool {
+    // Two-locations rule (the "2" in 3-2-1)
+    if rec.backupDestinations.count >= 2 { return true }
+    // Lifecycle marker
+    if rec.archiveStage.rawValue == ArchiveStage.healthy.rawValue { return true }
+    return false
+}
+
+/// Decide what to do with a single record given the band thresholds.
+/// Higher junkScore = MORE junky (less keepable) per the existing
+/// scoring convention; thresholds invert that for the human-friendly
+/// "auto-keep above N" reading.
+///
+/// **Convention check:** in this codebase `junkScore` is a "junkiness"
+/// number — higher = more likely junk. So:
+/// - `junkScore >= autoJunkAbove` → auto-junk candidate
+/// - `junkScore <= autoKeepBelow` → auto-keep
+/// - between → queue for human
+nonisolated func pfTriageDisposition(
+    _ rec: VideoRecord,
+    autoKeepBelow: Int = 30,
+    autoJunkAbove: Int = 70,
+    requireBackupForJunk: Bool = true
+) -> TriageDisposition {
+    let s = rec.junkScore
+    if s >= autoJunkAbove {
+        if requireBackupForJunk && !pfRecordHasVerifiedBackup(rec) {
+            return .junkButNotBackedUp
+        }
+        return .autoJunk
+    }
+    if s <= autoKeepBelow {
+        return .autoKeep
+    }
+    return .queue
+}
+
+/// Filter a record list down to only the records that need a human
+/// triage call. Optionally include "junkButNotBackedUp" so the user
+/// can see why those weren't auto-junked.
+nonisolated func pfTriageQueueRecords(
+    from records: [VideoRecord],
+    autoKeepBelow: Int = 30,
+    autoJunkAbove: Int = 70,
+    includeUnbackedJunk: Bool = true
+) -> [VideoRecord] {
+    records.filter { rec in
+        let d = pfTriageDisposition(rec,
+                                    autoKeepBelow: autoKeepBelow,
+                                    autoJunkAbove: autoJunkAbove)
+        switch d {
+        case .queue: return true
+        case .junkButNotBackedUp: return includeUnbackedJunk
+        case .autoKeep, .autoJunk: return false
+        }
+    }
+}
+
+/// Aggregate counts for a triage dashboard.
+struct TriageBandCounts: Equatable {
+    var autoKeep: Int = 0
+    var queue: Int = 0
+    var autoJunk: Int = 0
+    var junkButNotBackedUp: Int = 0
+    var total: Int { autoKeep + queue + autoJunk + junkButNotBackedUp }
+}
+
+nonisolated func pfTriageBandCounts(
+    from records: [VideoRecord],
+    autoKeepBelow: Int = 30,
+    autoJunkAbove: Int = 70
+) -> TriageBandCounts {
+    var counts = TriageBandCounts()
+    for rec in records {
+        switch pfTriageDisposition(rec,
+                                   autoKeepBelow: autoKeepBelow,
+                                   autoJunkAbove: autoJunkAbove) {
+        case .autoKeep:           counts.autoKeep += 1
+        case .queue:              counts.queue += 1
+        case .autoJunk:           counts.autoJunk += 1
+        case .junkButNotBackedUp: counts.junkButNotBackedUp += 1
+        }
+    }
+    return counts
+}

--- a/VideoScan/VideoScanTests/CatalogQueriesTests.swift
+++ b/VideoScan/VideoScanTests/CatalogQueriesTests.swift
@@ -1,0 +1,332 @@
+import Testing
+import Foundation
+@testable import VideoScan
+
+// MARK: - Universal search tests (Issue #66, pattern 2)
+
+struct UniversalSearchTokenTests {
+
+    // regression: #66 — Whitespace splits a query into separate tokens
+    @Test func multipleTokens() {
+        let toks = pfTokenizeSearchQuery("donna holiday 1990")
+        #expect(toks == [.substring("donna"), .substring("holiday"), .substring("1990")])
+    }
+
+    // regression: #66 — Empty query yields zero tokens (matches everything downstream)
+    @Test func emptyQuery() {
+        #expect(pfTokenizeSearchQuery("").isEmpty)
+        #expect(pfTokenizeSearchQuery("    ").isEmpty)
+    }
+
+    // regression: #66 — Decade shorthand "1990s" expands to 1990...1999
+    @Test func decadeShorthand1990s() {
+        let toks = pfTokenizeSearchQuery("1990s")
+        #expect(toks == [.yearRange(1990...1999)])
+    }
+
+    // regression: #66 — Decade shorthand "199x" expands to 1990...1999
+    @Test func wildcardShorthand199x() {
+        let toks = pfTokenizeSearchQuery("199x")
+        #expect(toks == [.yearRange(1990...1999)])
+    }
+
+    // regression: #66 — "200x" expands to 2000...2009
+    @Test func wildcardShorthand200x() {
+        let toks = pfTokenizeSearchQuery("200x")
+        #expect(toks == [.yearRange(2000...2009)])
+    }
+
+    // regression: #66 — "1995s" is NOT a decade (last digit not 0); falls back to substring
+    @Test func nonDecadeRejectedAsRange() {
+        let toks = pfTokenizeSearchQuery("1995s")
+        #expect(toks == [.substring("1995s")])
+    }
+
+    // regression: #66 — Mixed substring + range tokens preserved in order
+    @Test func mixedTokens() {
+        let toks = pfTokenizeSearchQuery("donna 1990s family")
+        #expect(toks == [
+            .substring("donna"),
+            .yearRange(1990...1999),
+            .substring("family"),
+        ])
+    }
+}
+
+struct UniversalSearchYearExtractionTests {
+
+    private func record(path: String, dateModified: Date? = nil) -> VideoRecord {
+        let r = VideoRecord()
+        r.fullPath = path
+        r.directory = (path as NSString).deletingLastPathComponent
+        r.filename = (path as NSString).lastPathComponent
+        r.dateModifiedRaw = dateModified
+        return r
+    }
+
+    // regression: #66 — Year embedded in a path component is extracted
+    @Test func yearInPath() {
+        let r = record(path: "/Volumes/Drive/holiday_1995/clip.mov")
+        #expect(pfYearsFromRecord(r).contains(1995))
+    }
+
+    // regression: #66 — Year embedded in a filename is extracted
+    @Test func yearInFilename() {
+        let r = record(path: "/Volumes/Drive/holiday_1995.mov")
+        #expect(pfYearsFromRecord(r).contains(1995))
+    }
+
+    // regression: #66 — Embedded run of 5 digits is NOT a year (e.g. "199999")
+    @Test func ignoresLongerDigitRuns() {
+        let r = record(path: "/Volumes/Drive/something_1999999.mov")
+        #expect(!pfYearsFromRecord(r).contains(1999))
+    }
+
+    // regression: #66 — dateModifiedRaw year is included
+    @Test func dateModifiedYear() {
+        let cal = Calendar(identifier: .gregorian)
+        let date = cal.date(from: DateComponents(year: 2003, month: 6, day: 1))!
+        let r = record(path: "/v/clip.mov", dateModified: date)
+        #expect(pfYearsFromRecord(r).contains(2003))
+    }
+
+    // regression: #66 — Years out of range (1899, 2100) are ignored
+    @Test func rejectsOutOfRangeYears() {
+        let r = record(path: "/Volumes/2100abc/old_1899/clip.mov")
+        let years = pfYearsFromRecord(r)
+        #expect(!years.contains(2100))
+        #expect(!years.contains(1899))
+    }
+}
+
+struct UniversalSearchMatchingTests {
+
+    private func record(
+        path: String = "/v/clip.mov",
+        detectedPeople: [String] = [],
+        avidClipName: String = "",
+        videoCodec: String = "",
+        notes: String = ""
+    ) -> VideoRecord {
+        let r = VideoRecord()
+        r.fullPath = path
+        r.directory = (path as NSString).deletingLastPathComponent
+        r.filename = (path as NSString).lastPathComponent
+        r.detectedPeople = detectedPeople
+        r.avidClipName = avidClipName
+        r.videoCodec = videoCodec
+        r.notes = notes
+        return r
+    }
+
+    // regression: #66 — Empty query matches all records
+    @Test func emptyQueryMatchesAll() {
+        let r = record()
+        #expect(pfRecordMatchesQuery(r, query: "") == true)
+        #expect(pfRecordMatchesQuery(r, query: "   ") == true)
+    }
+
+    // regression: #66 — Single substring matches filename
+    @Test func filenameSubstringMatch() {
+        let r = record(path: "/v/holiday_1995.mov")
+        #expect(pfRecordMatchesQuery(r, query: "holiday") == true)
+        #expect(pfRecordMatchesQuery(r, query: "Holiday") == true) // case-insensitive
+    }
+
+    // regression: #66 — detectedPeople is searchable
+    @Test func detectedPeopleMatch() {
+        let r = record(detectedPeople: ["Donna", "Tim"])
+        #expect(pfRecordMatchesQuery(r, query: "donna") == true)
+        #expect(pfRecordMatchesQuery(r, query: "tim") == true)
+        #expect(pfRecordMatchesQuery(r, query: "fred") == false)
+    }
+
+    // regression: #66 — avidClipName is searchable
+    @Test func avidClipNameMatch() {
+        let r = record(avidClipName: "MyClip.V01.A01")
+        #expect(pfRecordMatchesQuery(r, query: "v01.a01") == true)
+    }
+
+    // regression: #66 — Codec string is searchable
+    @Test func codecMatch() {
+        let r = record(videoCodec: "h264")
+        #expect(pfRecordMatchesQuery(r, query: "h264") == true)
+        #expect(pfRecordMatchesQuery(r, query: "prores") == false)
+    }
+
+    // regression: #66 — Notes field is searchable
+    @Test func notesMatch() {
+        let r = record(notes: "wedding reception, mom's side")
+        #expect(pfRecordMatchesQuery(r, query: "wedding") == true)
+    }
+
+    // regression: #66 — Multi-token AND: both must match (people + year)
+    @Test func multiTokenAnd() {
+        let r = record(path: "/v/holiday_1995.mov", detectedPeople: ["Donna"])
+        #expect(pfRecordMatchesQuery(r, query: "donna 1995") == true)
+        // Both match: donna in detectedPeople AND 1995 in path
+        #expect(pfRecordMatchesQuery(r, query: "donna fred") == false)
+        // donna matches, fred doesn't
+    }
+
+    // regression: #66 — Year token matches via path-extracted year
+    @Test func yearTokenMatchesPath() {
+        let r = record(path: "/v/family_1992/clip.mov")
+        #expect(pfRecordMatchesQuery(r, query: "1990s") == true)
+        #expect(pfRecordMatchesQuery(r, query: "2000s") == false)
+    }
+
+    // regression: #66 — Wildcard year token works the same as decade
+    @Test func wildcardYearToken() {
+        let r = record(path: "/v/family_2003/clip.mov")
+        #expect(pfRecordMatchesQuery(r, query: "200x") == true)
+        #expect(pfRecordMatchesQuery(r, query: "199x") == false)
+    }
+
+    // regression: #66 — Realistic compound query
+    @Test func compoundQueryDonna1990sHoliday() {
+        let r = record(path: "/v/holiday_1995/clip.mov", detectedPeople: ["Donna"])
+        #expect(pfRecordMatchesQuery(r, query: "donna 1990s holiday") == true)
+    }
+
+    // regression: #66 — Bulk filter API returns the right slice
+    @Test func bulkFilterReturnsMatchingSlice() {
+        let recs = [
+            record(path: "/v/donna_1995.mov", detectedPeople: ["Donna"]),
+            record(path: "/v/tim_2005.mov", detectedPeople: ["Tim"]),
+            record(path: "/v/donna_2005.mov", detectedPeople: ["Donna"]),
+        ]
+        let donnaIn90s = pfRecordsMatchingQuery(recs, query: "donna 1990s")
+        #expect(donnaIn90s.count == 1)
+        #expect(donnaIn90s.first?.filename == "donna_1995.mov")
+    }
+}
+
+// MARK: - Triage disposition tests (Issue #66, pattern 3)
+
+struct TriageDispositionTests {
+
+    private func record(
+        junkScore: Int = 50,
+        backupCount: Int = 0,
+        archiveStage: ArchiveStage = .none
+    ) -> VideoRecord {
+        let r = VideoRecord()
+        r.fullPath = "/v/clip.mov"
+        r.junkScore = junkScore
+        r.archiveStage = archiveStage
+        r.backupDestinations = (0..<backupCount).map {
+            BackupEntry(name: "Backup\($0)", kind: .local, date: .now)
+        }
+        return r
+    }
+
+    // regression: #66 — junkScore <= autoKeepBelow → autoKeep
+    @Test func lowScoreYieldsAutoKeep() {
+        let r = record(junkScore: 10)
+        #expect(pfTriageDisposition(r) == .autoKeep)
+    }
+
+    // regression: #66 — junkScore at boundary (= 30) is autoKeep (inclusive)
+    @Test func autoKeepBoundaryIsInclusive() {
+        let r = record(junkScore: 30)
+        #expect(pfTriageDisposition(r) == .autoKeep)
+    }
+
+    // regression: #66 — Middle band → queue (human review)
+    @Test func middleBandYieldsQueue() {
+        let r = record(junkScore: 50)
+        #expect(pfTriageDisposition(r) == .queue)
+    }
+
+    // regression: #66 — junkScore >= autoJunkAbove + verified backup → autoJunk
+    @Test func highScoreWithBackupYieldsAutoJunk() {
+        let r = record(junkScore: 80, backupCount: 2)
+        #expect(pfTriageDisposition(r) == .autoJunk)
+    }
+
+    // regression: #66 — Backup gate: high score WITHOUT backup → junkButNotBackedUp (safety)
+    @Test func highScoreWithoutBackupNotAutoJunked() {
+        let r = record(junkScore: 80, backupCount: 0)
+        #expect(pfTriageDisposition(r) == .junkButNotBackedUp)
+    }
+
+    // regression: #66 — One backup is not enough; need 2-locations rule
+    @Test func singleBackupNotEnough() {
+        let r = record(junkScore: 80, backupCount: 1)
+        #expect(pfTriageDisposition(r) == .junkButNotBackedUp)
+    }
+
+    // regression: #66 — archiveStage = .healthy satisfies the backup gate
+    @Test func healthyArchiveStageSatisfiesGate() {
+        let r = record(junkScore: 80, backupCount: 0, archiveStage: .healthy)
+        #expect(pfTriageDisposition(r) == .autoJunk)
+    }
+
+    // regression: #66 — `requireBackupForJunk: false` skips the safety gate
+    @Test func disablingGateAllowsRiskyAutoJunk() {
+        let r = record(junkScore: 90, backupCount: 0)
+        #expect(pfTriageDisposition(r, requireBackupForJunk: false) == .autoJunk)
+    }
+}
+
+struct TriageQueueTests {
+
+    private func record(_ path: String, junkScore: Int, backupCount: Int = 0) -> VideoRecord {
+        let r = VideoRecord()
+        r.fullPath = path
+        r.filename = (path as NSString).lastPathComponent
+        r.junkScore = junkScore
+        r.backupDestinations = (0..<backupCount).map {
+            BackupEntry(name: "B\($0)", kind: .local, date: .now)
+        }
+        return r
+    }
+
+    // regression: #66 — Triage queue surfaces only borderline records
+    @Test func queueSurfacesOnlyBorderline() {
+        let recs = [
+            record("/v/keeper.mov", junkScore: 5),     // autoKeep (filtered out)
+            record("/v/borderline.mov", junkScore: 50),// queue (kept)
+            record("/v/junk.mov", junkScore: 90, backupCount: 2), // autoJunk (filtered)
+        ]
+        let queue = pfTriageQueueRecords(from: recs)
+        #expect(queue.count == 1)
+        #expect(queue.first?.filename == "borderline.mov")
+    }
+
+    // regression: #66 — junkButNotBackedUp included by default (visibility for safety)
+    @Test func includesUnbackedJunkByDefault() {
+        let recs = [
+            record("/v/risky.mov", junkScore: 90, backupCount: 0)
+        ]
+        let queue = pfTriageQueueRecords(from: recs)
+        #expect(queue.count == 1)
+    }
+
+    // regression: #66 — Setting includeUnbackedJunk: false hides them
+    @Test func canHideUnbackedJunk() {
+        let recs = [
+            record("/v/risky.mov", junkScore: 90, backupCount: 0)
+        ]
+        let queue = pfTriageQueueRecords(from: recs, includeUnbackedJunk: false)
+        #expect(queue.isEmpty)
+    }
+
+    // regression: #66 — Band counts split a mixed catalog correctly
+    @Test func bandCountsAggregate() {
+        let recs = [
+            record("/v/keep1.mov", junkScore: 5),
+            record("/v/keep2.mov", junkScore: 25),
+            record("/v/maybe.mov", junkScore: 50),
+            record("/v/junk.mov", junkScore: 85, backupCount: 2),
+            record("/v/risky.mov", junkScore: 90, backupCount: 0),
+        ]
+        let counts = pfTriageBandCounts(from: recs)
+        #expect(counts.autoKeep == 2)
+        #expect(counts.queue == 1)
+        #expect(counts.autoJunk == 1)
+        #expect(counts.junkButNotBackedUp == 1)
+        #expect(counts.total == 5)
+    }
+}


### PR DESCRIPTION
## Summary
Closes the remaining two patterns from #66 with pure-logic helpers + 31 regression tests. UI integration is a deliberate follow-up — this PR ships the core so the rules are locked under tests.

## Pattern 2: Universal search

`pfRecordMatchesQuery(_:query:)` does multi-token AND search across:
- filename, path, directory
- \`detectedPeople\`, \`avidClipName\`, video/audio codec
- \`lifecycleStage\`, \`archiveStage\`, notes

Year shorthand:
- \`"1990s"\` → 1990...1999
- \`"199x"\` → 1990...1999
- \`"200x"\` → 2000...2009
- \`"1995s"\` → falls back to substring (not a decade)

Years extracted from path components AND from \`dateModifiedRaw\` / \`dateCreatedRaw\`. Long digit runs (e.g. "1999999") rejected so we don't misread them as years.

**Example queries that work:**
- \`"donna 1990s holiday"\` — Donna in detectedPeople AND 199x year AND "holiday" in path
- \`"h264 200x"\` — H.264 footage from the 2000s
- \`"G2CL-86B"\` — POI ID match anywhere

## Pattern 3: Triage disposition

\`pfTriageDisposition(...)\` classifies each record into one of four buckets:

| Bucket | Condition |
|---|---|
| \`autoKeep\` | junkScore ≤ 30 |
| \`queue\` | 30 < junkScore < 70 (human attention required) |
| \`autoJunk\` | junkScore ≥ 70 AND verified backup |
| \`junkButNotBackedUp\` | junkScore ≥ 70 but no verified backup — queue it for safety |

**"Verified backup"** = ≥2 distinct \`BackupEntries\` (the 2-locations rule from 3-2-1 archive strategy) OR \`archiveStage == .healthy\`. Conservative on purpose — auto-delete only fires when we're CONFIDENT.

\`pfTriageQueueRecords(from:...)\` filters to just the human-attention slice. \`pfTriageBandCounts(from:...)\` aggregates for a future dashboard widget.

## Test plan
- [x] 31 new tests in \`CatalogQueriesTests.swift\`, all tagged \`// regression: #66\`
- [x] Debug build green
- [ ] Follow-up PR: wire universal search into Catalog tab toolbar
- [ ] Follow-up PR: wire triage queue into Triage tab (replace existing band logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)