### PR TITLE
Sendable migration batch 2: combine + thumbnail + triage (12 more warnings)

### DIFF
--- a/VideoScan/VideoScan/ProcessRunner.swift
+++ b/VideoScan/VideoScan/ProcessRunner.swift
@@ -271,7 +271,7 @@ enum ProcessRunner {
         }
     }
 
-    private final class CompletionBox<T>: @unchecked Sendable {
+    private final class CompletionBox<T: Sendable>: @unchecked Sendable {
         private let lock = NSLock()
         private var continuation: CheckedContinuation<T, Never>?
         private var result: T?

--- a/VideoScan/VideoScan/TriageView.swift
+++ b/VideoScan/VideoScan/TriageView.swift
@@ -520,14 +520,16 @@ struct TriageView: View {
 
     private func runAnalysis(records: [VideoRecord]) {
         isAnalyzing = true
-        DispatchQueue.global(qos: .userInitiated).async {
-            let summary = MediaAnalyzer.analyzeAll(records)
-            DispatchQueue.main.async {
-                analysisSummary = summary
-                showAnalysisSummary = true
-                isAnalyzing = false
-            }
-        }
+        // MediaAnalyzer.analyzeAll mutates each record in place
+        // (junkScore, mediaDisposition). Records are class instances,
+        // not Sendable, so can't cross to a background queue without
+        // racing. Until MediaAnalyzer is refactored to return a delta
+        // (per #66 architecture work), run synchronously on the actor
+        // that owns the records.
+        let summary = MediaAnalyzer.analyzeAll(records)
+        analysisSummary = summary
+        showAnalysisSummary = true
+        isAnalyzing = false
     }
 
     private func analysisBanner(_ summary: MediaAnalyzer.AnalysisSummary) -> some View {

--- a/VideoScan/VideoScan/VideoScanModel+Combine.swift
+++ b/VideoScan/VideoScan/VideoScanModel+Combine.swift
@@ -106,8 +106,8 @@ extension VideoScanModel {
     /// Process one video/audio pair end-to-end: skip-if-exists, pause-gate,
     /// stage inputs, mux, clean up. Returns true on success.
     func processCombinePair(
-        video: VideoRecord,
-        audio: VideoRecord,
+        video: VideoRecordSnapshot,
+        audio: VideoRecordSnapshot,
         outputFolder: URL,
         tempBase: URL,
         hasRAMDisk: Bool,
@@ -186,7 +186,7 @@ extension VideoScanModel {
         staged: (video: URL, audio: URL, tempDir: URL?),
         outURL: URL, outName: String,
         technique: CombineJobStatus.CombineTechnique,
-        video: VideoRecord, audio: VideoRecord,
+        video: VideoRecordSnapshot, audio: VideoRecordSnapshot,
         jobIndex: Int
     ) async -> Bool {
         await MainActor.run { self.updateJobPhase(jobIndex, .muxing) }
@@ -286,7 +286,7 @@ extension VideoScanModel {
         dashboard.combineJobs[index].phase = phase
     }
 
-    private func resolveCombineTechnique(video: VideoRecord, audio: VideoRecord, jobIndex: Int) async -> CombineJobStatus.CombineTechnique {
+    private func resolveCombineTechnique(video: VideoRecordSnapshot, audio: VideoRecordSnapshot, jobIndex: Int) async -> CombineJobStatus.CombineTechnique {
         var technique = await MainActor.run {
             guard jobIndex < self.dashboard.combineJobs.count else { return CombineJobStatus.CombineTechnique.streamCopy }
             return self.dashboard.combineJobs[jobIndex].technique
@@ -320,7 +320,7 @@ extension VideoScanModel {
     /// Build a catalog record for a successfully combined output file.
     /// Inherits the star rating from the source pair and links back via combinedFromPairID.
     nonisolated func buildCombinedRecord(
-        outputURL: URL, video: VideoRecord, audio: VideoRecord, summary: String
+        outputURL: URL, video: VideoRecordSnapshot, audio: VideoRecordSnapshot, summary: String
     ) async -> VideoRecord? {
         let (probe, _) = await CombineVerifier.runFFProbe(url: outputURL, ffprobePath: ffprobePath)
         guard let probe else { return nil }
@@ -470,12 +470,19 @@ extension VideoScanModel {
         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
         """)
 
+        // Snapshot the pairs once on the main actor before crossing into
+        // the Task / TaskGroup. VideoRecord is a class and would race;
+        // VideoRecordSnapshot is Sendable so the TaskGroup body can
+        // capture it freely.
+        let snapshotPairs: [(video: VideoRecordSnapshot, audio: VideoRecordSnapshot)] =
+            filteredPairs.map { (video: $0.video.snapshot(), audio: $0.audio.snapshot()) }
+
         let newTask = Task {
             let (tempBase, hasRAMDisk) = await mountCombineRAMDisk()
             let semaphore = AsyncSemaphore(limit: maxConcurrency ?? self.perfSettings.combineConcurrency)
 
             await withTaskGroup(of: Bool.self) { group in
-                for (i, (video, audio)) in filteredPairs.enumerated() {
+                for (i, (video, audio)) in snapshotPairs.enumerated() {
                     if Task.isCancelled { break }
                     let jobIndex = jobOffset + i
                     group.addTask { [self] in

--- a/VideoScan/VideoScan/VideoScanModel.swift
+++ b/VideoScan/VideoScan/VideoScanModel.swift
@@ -2709,7 +2709,10 @@ final class VideoScanModel: ObservableObject {
 
         previewImage = nil
         let url = URL(fileURLWithPath: record.fullPath)
-        Task.detached {
+        // Capture the cache key as Sendable String, not NSString. Re-bridge
+        // inside the MainActor block where the NSCache lives.
+        let cacheKeyString = record.fullPath
+        Task.detached { [weak self] in
             let asset = AVURLAsset(url: url)
             let generator = AVAssetImageGenerator(asset: asset)
             generator.appliesPreferredTrackTransform = true
@@ -2722,16 +2725,18 @@ final class VideoScanModel: ObservableObject {
                         if let image { cont.resume(returning: image) } else { cont.resume(throwing: error ?? CocoaError(.fileReadUnknown)) }
                     }
                 }
-                // CGImage is Sendable; NSImage isn't. Build the NSImage on
-                // the main actor so we never cross actor boundaries with it.
+                // CGImage is Sendable; NSImage and NSString aren't. Build
+                // both on the main actor so we never cross actor boundaries
+                // with them.
                 await MainActor.run {
+                    guard let self else { return }
                     let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-                    self.thumbnailCache.setObject(nsImage, forKey: cacheKey)
+                    self.thumbnailCache.setObject(nsImage, forKey: cacheKeyString as NSString)
                     self.previewImage = nsImage
                 }
             } catch {
-                await MainActor.run {
-                    self.previewImage = nil
+                await MainActor.run { [weak self] in
+                    self?.previewImage = nil
                 }
             }
         }


### PR DESCRIPTION
## Summary
Builds on the `VideoRecordSnapshot` foundation from #73. Migrates four more cross-actor sites; **strict-concurrency warning count: 79 → 67 (-12)**.

## Sites migrated
| Site | Before | After |
|---|---|---|
| Combine pipeline (`processCombinePair`, `buildCombinedRecord`, `resolveCombineTechnique`, `runMuxAndVerify`) | 5 | 0 |
| Triage analyse (`runAnalysis`) | 1 | 0 |
| ProcessRunner `CompletionBox<T>` | 4 | 0 |
| Thumbnail Task.detached (cacheKey + self) | 2 | 0 |

## Notable design notes
- **Combine pipeline**: snapshots pairs once at TaskGroup entry; all four functions take `VideoRecordSnapshot`. The newly-built combined record is a fresh allocation inside `buildCombinedRecord`, so the migration is clean — no shared mutation across actors.
- **TriageView**: `MediaAnalyzer.analyzeAll` mutates records in-place (writes `junkScore`, `mediaDisposition`). The previous `DispatchQueue.global` was already-broken under strict concurrency; runs synchronously now. Comment notes the proper fix is a delta-returning analyzeAll, deferred.
- **ProcessRunner**: `CompletionBox<T>` generic was unconstrained — adding `T: Sendable` is the right answer.
- **Thumbnail**: NSString isn't Sendable; capture cacheKey as String and bridge inside MainActor block.

## What's still in VideoScanModel.swift (35 warnings)
Structural — `probeAndRecord` and `scanOneRootParallel` return `VideoRecord` / `[VideoRecord]` to nonisolated callers. Migrating means changing return types to snapshots, with the caller constructing catalog records on MainActor. Filed as follow-up: **#74**.

## Test plan
- [x] Combine engine tests green (`CombineEngineTests`, `CombineEngineExtendedTests`, `CombineTechniquePropagationTests`)
- [x] Strict-concurrency clean rebuild: 67 warnings (down from 79)
- [ ] Run a real combine on a V/A pair to confirm pipeline still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)