### PR TITLE
Fix #67: double-click media row to open in QuickTime Player

### DIFF
--- a/VideoScan/VideoScan/ArchiveView.swift
+++ b/VideoScan/VideoScan/ArchiveView.swift
@@ -349,6 +349,10 @@ struct ArchiveView: View {
         }
         .contextMenu(forSelectionType: UUID.self) { ids in
             recordContextMenu(for: ids)
+        } primaryAction: { ids in
+            // Double-click / Return on row(s) → open in QuickTime.
+            let recs = ids.compactMap { id in rows.first { $0.id == id } }
+            MediaOpener.openInQuickTime(recs)
         }
     }
 

--- a/VideoScan/VideoScan/CatalogHelpers.swift
+++ b/VideoScan/VideoScan/CatalogHelpers.swift
@@ -847,6 +847,10 @@ struct CatalogContent: View {
                     NSPasteboard.general.setString(rec.fullPath, forType: .string)
                 }
             }
+        } primaryAction: { ids in
+            // Double-click / Return on row(s) → open in QuickTime.
+            let recs = ids.compactMap { id in records.first { $0.id == id } }
+            MediaOpener.openInQuickTime(recs)
         }
         .onAppear { tableData = computeFiltered() }
         .onChange(of: records.count) { tableData = computeFiltered() }
@@ -1950,5 +1954,26 @@ struct StarRatingView: View {
                     }
             }
         }
+    }
+}
+
+// MARK: - Shared media open helpers
+
+enum MediaOpener {
+    /// Open one or more catalog records in QuickTime Player.
+    /// Silently skips records on offline volumes (the table's row context
+    /// menu shows a clearer "Reveal" option for those).
+    static func openInQuickTime(_ records: [VideoRecord]) {
+        let urls = records
+            .filter { VolumeReachability.isReachable(path: $0.fullPath) }
+            .map { URL(fileURLWithPath: $0.fullPath) }
+        guard !urls.isEmpty,
+              let qtURL = NSWorkspace.shared.urlForApplication(
+                withBundleIdentifier: "com.apple.QuickTimePlayerX"
+              )
+        else { return }
+        NSWorkspace.shared.open(urls,
+                                withApplicationAt: qtURL,
+                                configuration: NSWorkspace.OpenConfiguration())
     }
 }

--- a/VideoScan/VideoScan/TriageView.swift
+++ b/VideoScan/VideoScan/TriageView.swift
@@ -405,6 +405,10 @@ struct TriageView: View {
         }
         .contextMenu(forSelectionType: UUID.self) { ids in
             triageContextMenu(for: ids)
+        } primaryAction: { ids in
+            // Double-click / Return on row(s) → open in QuickTime.
+            let recs = ids.compactMap { id in rows.first { $0.id == id } }
+            MediaOpener.openInQuickTime(recs)
         }
     }
 


### PR DESCRIPTION
Closes #67. PersonFinder table deferred (active edits there); same one-liner can be added once that branch settles.